### PR TITLE
refactor: introduce TailwindClass value object

### DIFF
--- a/src/__tests__/unit/utils.test.ts
+++ b/src/__tests__/unit/utils.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   toSides,
-  extractTailwindClasses,
   toHex,
   escapeHTML,
   debounce,
@@ -65,36 +64,6 @@ describe("Utils Functions", () => {
     });
   });
 
-  describe("extractTailwindClasses", () => {
-    it("should extract valid Tailwind classes", () => {
-      const className =
-        "bg-red-500 text-white p-4 hover:bg-red-600 custom-class";
-      const result = extractTailwindClasses(className);
-      expect(result).toBe(
-        "bg-red-500 text-white p-4 hover:bg-red-600 custom-class"
-      );
-    });
-
-    it("should filter out invalid class names", () => {
-      const className = "bg-red-500 @invalid!class text-white p-4";
-      const result = extractTailwindClasses(className);
-      expect(result).toBe("bg-red-500 text-white p-4");
-    });
-
-    it("should handle empty or null input", () => {
-      expect(extractTailwindClasses("")).toBe("");
-      expect(extractTailwindClasses(null as any)).toBe("");
-      expect(extractTailwindClasses(undefined as any)).toBe("");
-    });
-
-    it("should handle responsive and pseudo-class prefixes", () => {
-      const className =
-        "sm:bg-blue-500 md:text-lg lg:p-8 hover:scale-105 focus:ring-2";
-      const result = extractTailwindClasses(className);
-      expect(result).toBe(
-        "sm:bg-blue-500 md:text-lg lg:p-8 hover:scale-105 focus:ring-2"
-      );
-    });
   });
 
   describe("toHex", () => {

--- a/src/core/domain/model/TailwindClass.test.ts
+++ b/src/core/domain/model/TailwindClass.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { TailwindClass } from "./TailwindClass";
+
+describe("TailwindClass", () => {
+  describe("parse", () => {
+    it("should extract valid Tailwind classes", () => {
+      const className = "bg-red-500 text-white p-4 hover:bg-red-600 custom-class";
+      const result = TailwindClass.parse(className).map((c) => c.toString()).join(" ");
+      expect(result).toBe("bg-red-500 text-white p-4 hover:bg-red-600 custom-class");
+    });
+
+    it("should filter out invalid class names", () => {
+      const className = "bg-red-500 @invalid!class text-white p-4";
+      const result = TailwindClass.parse(className).map((c) => c.toString()).join(" ");
+      expect(result).toBe("bg-red-500 text-white p-4");
+    });
+
+    it("should handle empty or null input", () => {
+      expect(TailwindClass.parse("")).toEqual([]);
+      expect(TailwindClass.parse(null as any)).toEqual([]);
+      expect(TailwindClass.parse(undefined as any)).toEqual([]);
+    });
+
+    it("should handle responsive and pseudo-class prefixes", () => {
+      const className = "sm:bg-blue-500 md:text-lg lg:p-8 hover:scale-105 focus:ring-2";
+      const result = TailwindClass.parse(className).map((c) => c.toString()).join(" ");
+      expect(result).toBe("sm:bg-blue-500 md:text-lg lg:p-8 hover:scale-105 focus:ring-2");
+    });
+  });
+});

--- a/src/core/domain/model/TailwindClass.ts
+++ b/src/core/domain/model/TailwindClass.ts
@@ -1,0 +1,16 @@
+export class TailwindClass {
+  constructor(private readonly value: string) {}
+
+  toString(): string {
+    return this.value;
+  }
+
+  static parse(className: string): TailwindClass[] {
+    if (!className) return [];
+    return String(className)
+      .split(/\s+/)
+      .filter((c) => /^[a-z0-9:_\/-]+$/i.test(c))
+      .map((c) => new TailwindClass(c));
+  }
+}
+

--- a/src/hooks/useInspector.ts
+++ b/src/hooks/useInspector.ts
@@ -2,11 +2,11 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { TooltipData } from "../types";
 import {
   toSides,
-  extractTailwindClasses,
   createToast,
   createSegmentWithLabel,
   debounce,
 } from "../utils";
+import { TailwindClass } from "../core/domain/model/TailwindClass";
 
 export const useInspector = () => {
   const [enabled, setEnabled] = useState(() => {
@@ -74,7 +74,7 @@ export const useInspector = () => {
         const pad = toSides(cs, "padding");
         const mar = toSides(cs, "margin");
 
-        const classes = extractTailwindClasses(el.className);
+        const classes = TailwindClass.parse(el.className).map((c) => c.toString()).join(" ");
         setTooltipData({
           classes,
           fg: cs.color,
@@ -112,7 +112,7 @@ export const useInspector = () => {
           const pad = toSides(cs, "padding");
           const mar = toSides(cs, "margin");
 
-          const classes = extractTailwindClasses(el.className);
+          const classes = TailwindClass.parse(el.className).map((c) => c.toString()).join(" ");
           setTooltipData({
             classes,
             fg: cs.color,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,13 +20,6 @@ export function toSides(cs: CSSStyleDeclaration, prop: string): Sides {
   };
 }
 
-export function extractTailwindClasses(className: string): string {
-  if (!className) return "";
-  return String(className)
-    .split(/\s+/)
-    .filter((c) => /^[a-z0-9:_\/-]+$/i.test(c))
-    .join(" ");
-}
 
 export function toHex(color: string): string {
   if (!color) return "";


### PR DESCRIPTION
## Summary
- start DDD migration with core domain model for Tailwind class parsing
- use `TailwindClass.parse` in inspector hook instead of util function
- add unit tests for parsing Tailwind classes

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b064610bd0832eb085ee221fe3b52d